### PR TITLE
Display space status in the category channel name

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -38,7 +38,8 @@ client = discord.Client(intents=intents)
 async def update_state(state, persons):
     if client.user:
         logging.info(f'Updating the presence to "{state}, {persons}"')
-        nick = f"{usernames[state]} ({persons} {people_indicator})" if state == 'open' and persons is not None else usernames[state]
+        nick = f"{usernames[state]} ({persons} {people_indicator})" if state == 'open' and persons is not None \
+            else usernames[state]
         for guild in client.guilds:
             member = guild.get_member_named(client.user.name)
             await member.edit(nick=nick)

--- a/bot.py
+++ b/bot.py
@@ -9,6 +9,7 @@ from discord.ext import tasks
 
 discord_token = os.getenv('DISCORD_TOKEN')
 space_endpoint = os.getenv('SPACE_ENDPOINT')
+channel_id = os.getenv('DISCORD_CHANNEL_ID')
 
 avatars = {}
 usernames = {
@@ -22,6 +23,7 @@ online_status = {
 }
 
 people_indicator = '🧙'
+channel_name = 'INFORMACJA 📑'
 
 current_state = None
 current_persons = None
@@ -36,13 +38,16 @@ client = discord.Client(intents=intents)
 async def update_state(state, persons):
     if client.user:
         logging.info(f'Updating the presence to "{state}, {persons}"')
+        nick = f"{usernames[state]} ({persons} {people_indicator})" if state == 'open' and persons is not None else usernames[state]
         for guild in client.guilds:
             member = guild.get_member_named(client.user.name)
-            nick = usernames[state]
-            if state == 'open':
-                if persons is not None:
-                    nick = f"{usernames[state]} ({persons} {people_indicator})"
             await member.edit(nick=nick)
+
+            channel = guild.get_channel(channel_id)
+            if channel:
+                channel_state = "🔒" if state == "closed" else f"🔓"
+                logging.warning(f'Channel name: {channel_name} [{channel_state}]')
+                await channel.edit(name=f"{channel_name} [{channel_state}]")
 
 
 async def update_presence(state, persons):

--- a/bot.py
+++ b/bot.py
@@ -47,7 +47,6 @@ async def update_state(state, persons):
             channel = guild.get_channel(channel_id)
             if channel:
                 channel_state = "🔒" if state == "closed" else f"🔓/{persons or "?"}"
-                logging.warning(f'Channel name: {channel_name} [{channel_state}]')
                 await channel.edit(name=f"{channel_name} [{channel_state}]")
 
 

--- a/bot.py
+++ b/bot.py
@@ -45,7 +45,7 @@ async def update_state(state, persons):
 
             channel = guild.get_channel(channel_id)
             if channel:
-                channel_state = "🔒" if state == "closed" else f"🔓"
+                channel_state = "🔒" if state == "closed" else f"🔓/{persons or "?"}"
                 logging.warning(f'Channel name: {channel_name} [{channel_state}]')
                 await channel.edit(name=f"{channel_name} [{channel_state}]")
 


### PR DESCRIPTION
Really annoying to check the space status on the phone, having to do multiple clicks to get to the bot nickname (especially when not in the channel that it has access to)

1. Bot would require `Manage Channels` permission
2. `DISCORD_CHANNEL_ID` env var should be created

![image](https://github.com/user-attachments/assets/ecbcf7d0-d5f3-44fe-aae4-82f8fc1a86b6)
