### PR TITLE
Fix synchronization issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ docker run -e DISCORD_TOKEN='discord-bot-token' \
 4. Submit a pull request.
 
 ## License
-This project is licensed under the terms of the [MIT](LICENSE) file.
+This project is licensed under the terms of the [MIT](LICENSE).

--- a/bot.py
+++ b/bot.py
@@ -28,37 +28,43 @@ intents = discord.Intents.default()
 client = discord.Client(intents=intents)
 
 
-async def update_state(state, persons):
-    if client.user:
-        logging.info(f'Updating the presence to "{state}, {persons}"')
-        nick = (
-            f'{usernames[state]} ({persons} {people_indicator})'
-            if state == 'open' and persons is not None
-            else usernames[state]
-        )
-        for guild in client.guilds:
-            member = guild.get_member_named(client.user.name)
-            await member.edit(nick=nick)
-
-            # Getting channel ID and setting status for it
-            channel = guild.get_channel(int(channel_id))
-            if channel:
-                # Setting lock emoji and actual status
-                lock_icon = '🔴🔒' if state == 'closed' else '🟢🔓'
-                channel_state = 'closed' if state == 'closed' else f"open-{persons or '?'}"
-                formatted_channel_name = f'{lock_icon}-{channel_name}-{channel_state}'
-
-                # Setting actual status
-                await channel.edit(name=formatted_channel_name)
-            else:
-                logging.warning(f'Channel {channel_id} not found')
-
-
 async def update_presence(state, persons):
     global current_state, current_persons
 
+    # Only proceed if there's an actual change
     if state != current_state or persons != current_persons:
-        await update_state(state, persons)
+        logging.info(f'Updating the presence to "{state}, {persons}"')
+
+        if client.user:
+            nick = (
+                f'{usernames[state]} ({persons} {people_indicator})'
+                if state == 'open' and persons is not None
+                else usernames[state]
+            )
+
+            # Get lock emoji and formatted channel name
+            lock_icon = '🔴🔒' if state == 'closed' else '🟢🔓'
+            channel_state = 'closed' if state == 'closed' else f"open-{persons or '?'}"
+            formatted_channel_name = f'{lock_icon}-{channel_name}-{channel_state}'
+
+            for guild in client.guilds:
+                member = guild.get_member(client.user.id)
+                if member:
+                    await member.edit(nick=nick)
+
+                channel = guild.get_channel(int(channel_id))
+                if channel:
+                    await channel.edit(name=formatted_channel_name)
+                else:
+                    logging.warning(f'Channel {channel_id} not found')
+
+            if state != current_state:
+                try:
+                    await client.user.edit(avatar=avatars[state])
+                except Exception as e:
+                    logging.error(f'Failed to update avatar {state}: {e}')
+
+        # After successful update, store the new state
         current_state = state
         current_persons = persons
 
@@ -67,40 +73,42 @@ async def update_presence(state, persons):
 @tasks.loop(minutes=1)
 async def is_there_life_on_mars():
     logging.info('Checking the status')
-    spaceapi_json = requests.get(space_endpoint).json()
-    if spaceapi_json['state']['open']:
-        space_state = 'open'
-    else:
-        space_state = 'closed'
-
     try:
-        people = spaceapi_json['sensors']['people_now_present'][0].get('value', 0)
-        if isinstance(people, str):
-            people = int(float(people))
-        else:
-            people = int(people)
-    except (TypeError, ValueError) as e:
-        logging.warning(f'Failed to parse people_now_present value: {e}')
-        people = 0
+        response = requests.get(space_endpoint, timeout=10)
+        spaceapi_json = response.json()
+        space_state = 'open' if spaceapi_json['state']['open'] else 'closed'
+        try:
+            people = spaceapi_json['sensors']['people_now_present'][0].get('value', 0)
+            if isinstance(people, str):
+                people = int(float(people))
+            else:
+                people = int(people)
+        except (TypeError, ValueError, IndexError) as e:
+            logging.warning(f'Failed to parse people_now_present value: {e}')
+            people = 0
 
-    logging.info(f'Current status: {space_state} ({people} in da haus)')
-    await update_presence(space_state, people)
+        logging.info(f'Current status: {space_state} ({people} in da haus)')
+        await update_presence(space_state, people)
+
+    except Exception as e:
+        logging.error(f"Error fetching or processing space status: {e}")
 
 
 @client.event
 async def on_ready():
     for guild in client.guilds:
         logging.info(f'{client.user} has connected to Discord server {guild} using endpoint {space_endpoint}!')
-    for state in ['closed', 'open']:
-        with open(f'res/glider_{state}.png', 'rb') as avatar:
-            avatars[state] = avatar.read()
-    try:
-        await client.user.edit(username='glider')
-        await client.user.edit(avatar=avatars['open'])
-        await client.change_presence(activity=discord.Activity(name='the Space', type=discord.ActivityType.watching))
-    except:
-        logging.error(traceback.format_exc())
-    is_there_life_on_mars.start()
 
+    try:
+        for state in ['closed', 'open']:
+            with open(f'res/glider_{state}.png', 'rb') as avatar:
+                avatars[state] = avatar.read()
+
+        await client.user.edit(username='glider')
+        await client.change_presence(activity=discord.Activity(name='the Space', type=discord.ActivityType.watching))
+
+        is_there_life_on_mars.start()
+    except Exception as e:
+        logging.error(f"Error during initialization: {traceback.format_exc()}")
 
 client.run(discord_token)


### PR DESCRIPTION
# Problem
The bot was suffering from a synchronization issue where the channel name and bot nickname would get out of sync. When the space status changed, the channel would sometimes display the previous state instead of updating correctly with the bot's nickname.

# Changes
- Combined `update_state` and `update_presence` functions into a single atomic update function to ensure synchronization
- Added proper state tracking to only update when there's an actual change
- Fixed avatar updates to only trigger when the state changes
- Improved error handling for API requests and avatar updates
- Fixed member lookup to use `guild.get_member(client.user.id)` instead of `get_member_named`
- Fixed initialization in `on_ready` to prevent executing code multiple times in a loop
- Added timeout to API request